### PR TITLE
Add release_name output to npm publish workflow

### DIFF
--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -34,11 +34,14 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      release_name: ${{ steps.set_release_name.outputs.release_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Set release name
+        id: set_release_name
         run: |
           if [ -z "${{ inputs.release_name }}" ]; then
             echo "release_name=nightly" >> $GITHUB_ENV

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -80,7 +80,7 @@ jobs:
         if: ${{ inputs.publish_package }}
         uses: JS-DevTools/npm-publish@v2
         with:
-          tag: ${{ inputs.release_name }}
+          tag: ${{ env.release_name }}
           package: ./package.json
           registry: https://npm.pkg.github.com
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -35,7 +35,7 @@ jobs:
       contents: read
       packages: write
     outputs:
-      release_name: ${{ steps.set_release_name.outputs.release_name }}
+      release_name: ${{ env.release_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -26,6 +26,10 @@ on:
         required: false
         type: boolean
         default: false
+    outputs:
+      release_name:
+        description: 'Name of the release.'
+        value: ${{ jobs.buildAndPublish.outputs.release_name }}
 
 
 jobs:


### PR DESCRIPTION
## Description

Add release_name output to npm publish workflow.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

