### PR TITLE
Change publish method to command line

### DIFF
--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -109,6 +109,6 @@ jobs:
       - name: Publish package
         if: ${{ inputs.publish_package }}
         run: |
-          npm publish ${{ env.NPM_PUBLISH_PARAMETERS }} --tag ${{ env.release_name }} ${{ inputs.working_directory }}/package.json
+          npm publish ${{ env.NPM_PUBLISH_PARAMETERS }} --tag ${{ env.release_name }} ${{ inputs.working_directory }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -116,7 +116,8 @@ jobs:
 
       - name: Publish package
         if: ${{ inputs.publish_package }}
+        working-directory: ${{ inputs.working_directory }}
         run: |
-          npm publish ${{ env.NPM_PUBLISH_PARAMETERS }} --tag ${{ env.release_name }} ${{ inputs.working_directory }}
+          npm publish ${{ env.NPM_PUBLISH_PARAMETERS }} --tag ${{ env.release_name }}
         env:
           NODE_AUTH_TOKEN: ${{ env.node_token }}

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -36,10 +36,6 @@ on:
         required: false
         type: string
         default: '.'
-    secrets:
-      node_token:
-        description: 'GitHub token'
-        required: false
     outputs:
       release_name:
         description: 'Name of the release.'

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -62,6 +62,10 @@ jobs:
           else
             echo "release_name=${{ inputs.release_name }}" >> $GITHUB_ENV
           fi
+      
+      - name: Set registry URL
+        run: |
+          echo "npm_registry=https://npm.pkg.github.com" >> $GITHUB_ENV
 
       - name: "Set package version"
         working-directory: ${{ inputs.working_directory }}
@@ -84,16 +88,27 @@ jobs:
         if: ${{ inputs.build_package }}
         run: |
           echo '//npm.pkg.github.com/:_authToken="${{ secrets.GITHUB_TOKEN }}"' > ~/.npmrc
-          npm install --@flowforge:registry=https://npm.pkg.github.com
+          npm install --@flowforge:registry=${{ env.npm_registry }}
           npm run build
           rm -f ~/.npmrc
 
-      - name: "Publish package to private registry"
+      - name: Configure node
         if: ${{ inputs.publish_package }}
-        uses: JS-DevTools/npm-publish@v2
+        uses: actions/setup-node@v3
         with:
-          tag: ${{ env.release_name }}
-          package: ${{ inputs.working_directory }}/package.json
-          ignore-scripts: ${{ inputs.publish_ignore_scripts }}
-          registry: https://npm.pkg.github.com
-          token: ${{ secrets.GITHUB_TOKEN }}
+          node-version: '16'
+          registry-url: ${{ env.npm_registry }}
+      
+      - name: Set publish parameters
+        if: ${{ inputs.publish_package }}
+        run: |
+          if [ ${{ inputs.publish_ignore_scripts }} ]; then
+            echo "NPM_PUBLISH_PARAMETERS=--ignore-scripts" >> $GITHUB_ENV
+          fi
+
+      - name: Publish package
+        if: ${{ inputs.publish_package }}
+        run: |
+          npm publish ${{ env.NPM_PUBLISH_PARAMETERS }} --tag ${{ env.release_name }} ${{ inputs.working_directory }}/package.json
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           npm version prerelease --preid `git rev-parse --short HEAD`-`date +%Y%m%d` --no-git-tag-version
 
-      - name: "Set dependecies versions"
+      - name: Set dependecies versions
         if: ${{ inputs.package_dependencies != '' }}
         working-directory: ${{ inputs.working_directory }}
         run: |
@@ -87,23 +87,25 @@ jobs:
             mv package.json-patched package.json
           done
           cat package.json  
-
-      - name: "Build package"
-        if: ${{ inputs.build_package }}
-        run: |
-          echo '//npm.pkg.github.com/:_authToken="${{ secrets.GITHUB_TOKEN }}"' > ~/.npmrc
-          npm install --@flowforge:registry=${{ env.npm_registry }}
-          npm run build
-          rm -f ~/.npmrc
-
-      - name: Configure node for package publ;ish
-        if: ${{ inputs.publish_package }}
+      
+      - name: Configure node
+        if: |
+          inputs.publish_package ||
+          inputs.build_package
         uses: actions/setup-node@v3
         with:
           node-version: '16'
           registry-url: '${{ env.npm_registry }}'
           scope: '@flowforge'
           always-auth: true
+
+      - name: Build package
+        if: ${{ inputs.build_package }}
+        run: |
+          npm install --@flowforge:registry=${{ env.npm_registry }}
+          npm run build
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Set package publish parameters
         if: ${{ inputs.publish_package }}

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -36,6 +36,10 @@ on:
         required: false
         type: string
         default: '.'
+    secrets:
+      node_token:
+        description: 'GitHub token'
+        required: true
     outputs:
       release_name:
         description: 'Name of the release.'
@@ -113,4 +117,4 @@ jobs:
         run: |
           npm publish ${{ env.NPM_PUBLISH_PARAMETERS }} --tag ${{ env.release_name }} ${{ inputs.working_directory }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.node_token }}

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -92,14 +92,16 @@ jobs:
           npm run build
           rm -f ~/.npmrc
 
-      - name: Configure node
+      - name: Configure node for package publ;ish
         if: ${{ inputs.publish_package }}
         uses: actions/setup-node@v3
         with:
           node-version: '16'
-          registry-url: ${{ env.npm_registry }}
+          registry-url: '${{ env.npm_registry }}'
+          scope: '@flowforge'
+          always-auth: true
       
-      - name: Set publish parameters
+      - name: Set package publish parameters
         if: ${{ inputs.publish_package }}
         run: |
           if [ ${{ inputs.publish_ignore_scripts }} ]; then

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -36,6 +36,10 @@ on:
         required: false
         type: string
         default: '.'
+    secrets:
+      node_token:
+        description: 'Node registry authentication token'
+        required: true
     outputs:
       release_name:
         description: 'Name of the release.'
@@ -101,7 +105,7 @@ jobs:
           npm install --@flowforge:registry=${{ env.npm_registry }}
           npm run build
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.node_token }}
       
       - name: Set package publish parameters
         if: ${{ inputs.publish_package }}
@@ -115,4 +119,4 @@ jobs:
         run: |
           npm publish ${{ env.NPM_PUBLISH_PARAMETERS }} --tag ${{ env.release_name }} ${{ inputs.working_directory }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.node_token }}

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -36,10 +36,6 @@ on:
         required: false
         type: string
         default: '.'
-    secrets:
-      node_token:
-        description: 'Node registry authentication token'
-        required: true
     outputs:
       release_name:
         description: 'Name of the release.'
@@ -70,6 +66,10 @@ jobs:
       - name: Set registry URL
         run: |
           echo "npm_registry=https://npm.pkg.github.com" >> $GITHUB_ENV
+
+      - name: Set node token
+        run: |
+          echo "node_token=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
 
       - name: "Set package version"
         working-directory: ${{ inputs.working_directory }}
@@ -105,7 +105,7 @@ jobs:
           npm install --@flowforge:registry=${{ env.npm_registry }}
           npm run build
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.node_token }}
+          NODE_AUTH_TOKEN: ${{ env.node_token }}
       
       - name: Set package publish parameters
         if: ${{ inputs.publish_package }}
@@ -119,4 +119,4 @@ jobs:
         run: |
           npm publish ${{ env.NPM_PUBLISH_PARAMETERS }} --tag ${{ env.release_name }} ${{ inputs.working_directory }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.node_token }}
+          NODE_AUTH_TOKEN: ${{ env.node_token }}

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -39,7 +39,7 @@ on:
     secrets:
       node_token:
         description: 'GitHub token'
-        required: true
+        required: false
     outputs:
       release_name:
         description: 'Name of the release.'
@@ -117,4 +117,4 @@ jobs:
         run: |
           npm publish ${{ env.NPM_PUBLISH_PARAMETERS }} --tag ${{ env.release_name }} ${{ inputs.working_directory }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.node_token }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Change publish method to command line

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

