### PR TITLE
Extend package version preid pattern

### DIFF
--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -74,7 +74,7 @@ jobs:
       - name: "Set package version"
         working-directory: ${{ inputs.working_directory }}
         run: |
-          npm version prerelease --preid `git rev-parse --short HEAD`-`date +%Y%m%d` --no-git-tag-version
+          npm version prerelease --preid `git rev-parse --short HEAD`-`date +%Y%m%d%H%M` --no-git-tag-version
 
       - name: Set dependecies versions
         if: ${{ inputs.package_dependencies != '' }}


### PR DESCRIPTION
## Description

Change package version preid pattern from `git rev-parse --short HEAD-date +%Y%m%d%H%M` to `git rev-parse --short HEAD-date +%Y%m%d%H%M`

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

