### PR TITLE
Replace `npm_test` action with regular steps

### DIFF
--- a/.github/workflows/build_node_package.yml
+++ b/.github/workflows/build_node_package.yml
@@ -19,8 +19,20 @@ jobs:
         - name: Checkout
           uses: actions/checkout@v3
 
-        - name: NPM
-          uses: 'flowforge/github-actions-workflows/actions/npm_test@main'
+        - name: Use Node.js ${{ inputs.node_version }}
+          uses: actions/setup-node@v3
           with:
-            node_version: ${{ matrix.node-version }}
-            run_tests: ${{ inputs.run_tests }}
+            node-version: ${{ inputs.node_version }}
+    
+        - name: Install Dependencies
+          shell: bash
+          run: npm ci
+    
+        - name: Run lint
+          shell: bash
+          run: npm run lint
+    
+        - name: Run tests
+          if: ${{ inputs.run_tests == 'true' }}
+          shell: bash
+          run: npm run test

--- a/.github/workflows/build_node_package.yml
+++ b/.github/workflows/build_node_package.yml
@@ -16,23 +16,20 @@ jobs:
       matrix:
           node-version: [16.x]
     steps:
-        - name: Checkout
-          uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-        - name: Use Node.js ${{ inputs.node_version }}
-          uses: actions/setup-node@v3
-          with:
-            node-version: ${{ inputs.node_version }}
-    
-        - name: Install Dependencies
-          shell: bash
-          run: npm ci
-    
-        - name: Run lint
-          shell: bash
-          run: npm run lint
-    
-        - name: Run tests
-          if: ${{ inputs.run_tests == 'true' }}
-          shell: bash
-          run: npm run test
+      - name: Use Node.js ${{ inputs.node_version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ inputs.node_version }}
+  
+      - name: Install Dependencies
+        run: npm ci
+  
+      - name: Run lint
+        run: npm run lint
+  
+      - name: Run tests
+        if: ${{ inputs.run_tests == 'true' }}
+        run: npm run test

--- a/.github/workflows/build_node_package_with_pgsql.yml
+++ b/.github/workflows/build_node_package_with_pgsql.yml
@@ -29,11 +29,20 @@ jobs:
       matrix:
           node-version: [16.x]
     steps:
-        - name: Checkout
-          uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-        - name: NPM
-          uses: 'flowforge/github-actions-workflows/actions/npm_test@main'
-          with:
-            node_version: ${{ matrix.node-version }}
-            run_tests: ${{ inputs.run_tests }}
+      - name: Use Node.js ${{ inputs.node_version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ inputs.node_version }}
+  
+      - name: Install Dependencies
+        run: npm ci
+  
+      - name: Run lint
+        run: npm run lint
+  
+      - name: Run tests
+        if: ${{ inputs.run_tests == 'true' }}
+        run: npm run test


### PR DESCRIPTION
## Description

Replace the `npm_test` action with regular steps for a clearer workflow overview (composite action limitation).

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

