### PR TITLE
Remove unnecessary container image build arguments

### DIFF
--- a/.github/workflows/build_container_image.yml
+++ b/.github/workflows/build_container_image.yml
@@ -118,8 +118,6 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           build-args: |
-            REGISTRY=${{ inputs.npm_registry_url }}
-            REGISTRY_TOKEN=${{ secrets.npm_registry_auth_token }}
             BUILD_TAG=${{ env.build_tag }}
       
       - name: Scan container image for vulnerabilities


### PR DESCRIPTION
## Description

After switching to the public NPM packages registry, passing arguments related to registry authentication is no longer needed during the image build process.

## Related Issue(s)

[210](https://github.com/flowforge/CloudProject/issues/210)

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

