### PR TITLE
FIX: `manifest unknown` error during image pull

### DIFF
--- a/.github/workflows/build_container_image.yml
+++ b/.github/workflows/build_container_image.yml
@@ -117,6 +117,7 @@ jobs:
           tags: "ghcr.io/${{ github.repository_owner }}/${{ inputs.image_name }}:main-${{ env.platform_tag }}"
           platforms: ${{ matrix.platform }}
           push: true
+          provenance: false
           build-args: |
             BUILD_TAG=${{ env.build_tag }}
       

--- a/.github/workflows/build_container_image.yml
+++ b/.github/workflows/build_container_image.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Build container image
         id: build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: ${{ inputs.build_context }}
           file: "${{ inputs.build_context }}/${{ inputs.dockerfile_path }}"


### PR DESCRIPTION
## Description

After building a multiplatform container image with our workflow, an attempt to pull the image resulted in a `manifest unknown` error.
Setting the parameter `provenance` to `false` solves the problem.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

